### PR TITLE
fix: Event patterns with empty object properties causes error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ export class CreatedAccountByOrganizationsRule extends events.Rule {
  */
 export class CreatedAccountRule extends events.Rule {
   constructor(scope: Construct, id: string, props: OuRuleProps) {
-    const eventPattern = {
+    let eventPattern:any = {
       source: ['aws.controltower'],
       detailType: ['AWS Service Event via CloudTrail'],
       detail: {
@@ -140,15 +140,19 @@ export class CreatedAccountRule extends events.Rule {
         ],
         serviceEventDetails: {
           createManagedAccountStatus: {
-            organizationalUnit: {
-              organizationalUnitName: props.ouName,
-              organizationalUnitId: props.ouId,
-            },
             state: [props.eventState ?? EventStates.SUCCEEDED],
           },
         },
       },
     };
+
+    if (props.ouId || props.ouName) {
+      eventPattern.detail.serviceEventDetails.createManagedAccountStatus.organizationalUnit = {
+        organizationalUnitName: props.ouName,
+        organizationalUnitId: props.ouId,
+      };
+    };
+
     const description = props.description ?? 'A rule for new account creation in Control Tower.';
     super(scope, id, { eventPattern, description, ...props });
   }
@@ -159,7 +163,7 @@ export class CreatedAccountRule extends events.Rule {
  */
 export class UpdatedManagedAccountRule extends events.Rule {
   constructor(scope: Construct, id: string, props: AccountRuleProps) {
-    const eventPattern = {
+    let eventPattern:any = {
       source: ['aws.organizations'],
       detailType: ['AWS Service Event via CloudTrail'],
       detail: {
@@ -168,18 +172,24 @@ export class UpdatedManagedAccountRule extends events.Rule {
         ],
         serviceEventDetails: {
           updateManagedAccountStatus: {
-            organizationalUnit: {
-              organizationalUnitName: props.ouName,
-              organizationalUnitId: props.ouId,
-            },
-            account: {
-              accountName: props.accountName,
-              accountId: props.accountId,
-            },
             state: [props.eventState ?? EventStates.SUCCEEDED],
           },
         },
       },
+    };
+
+    if (props.ouId || props.ouName) {
+      eventPattern.detail.serviceEventDetails.updateManagedAccountStatus.organizationalUnit = {
+        organizationalUnitName: props.ouName,
+        organizationalUnitId: props.ouId,
+      };
+    };
+
+    if (props.accountId || props.accountName) {
+      eventPattern.detail.serviceEventDetails.updateManagedAccountStatus.account = {
+        accountName: props.accountName,
+        accountId: props.accountId,
+      };
     };
 
     const description = props.description ?? 'A rule for updated accounts managed by Control Tower.';
@@ -217,7 +227,7 @@ export class RegisteredOrganizationalUnitRule extends events.Rule {
  */
 export class DeregisteredOrganizationalUnitRule extends events.Rule {
   constructor(scope: Construct, id: string, props: OuRuleProps) {
-    const eventPattern = {
+    let eventPattern:any = {
       source: ['aws.controltower'],
       detailType: ['AWS Service Event via CloudTrail'],
       detail: {
@@ -226,15 +236,19 @@ export class DeregisteredOrganizationalUnitRule extends events.Rule {
         ],
         serviceEventDetails: {
           deregisterOrganizationalUnitStatus: {
-            organizationalUnit: {
-              organizationalUnitName: props.ouName,
-              organizationalUnitId: props.ouId,
-            },
             state: [props.eventState ?? EventStates.SUCCEEDED],
           },
         },
       },
     };
+
+    if (props.ouId || props.ouName) {
+      eventPattern.detail.serviceEventDetails.deregisterOrganizationalUnitStatus.organizationalUnit = {
+        organizationalUnitName: props.ouName,
+        organizationalUnitId: props.ouId,
+      };
+    };
+
     const description = props.description ?? 'A rule for deregistered OUs in Control Tower.';
     super(scope, id, { eventPattern, description, ...props });
   }
@@ -245,7 +259,7 @@ export class DeregisteredOrganizationalUnitRule extends events.Rule {
  */
 export class DisabledGuardrailRule extends events.Rule {
   constructor(scope: Construct, id: string, props: GuardrailRuleProps) {
-    const eventPattern = {
+    let eventPattern:any = {
       source: ['aws.organizations'],
       detailType: ['AWS Service Event via CloudTrail'],
       detail: {
@@ -254,22 +268,28 @@ export class DisabledGuardrailRule extends events.Rule {
         ],
         serviceEventDetails: {
           disableGuardrailStatus: {
-            organizationalUnits: [
-              {
-                organizationalUnitName: props.ouName,
-                organizationalUnitId: props.ouId,
-              },
-            ],
-            guardrails: [
-              {
-                guardrailId: props.guardrailId,
-                guardrailBehavior: props.guardrailBehavior,
-              },
-            ],
             state: [props.eventState ?? EventStates.SUCCEEDED],
           },
         },
       },
+    };
+
+    if (props.ouId || props.ouName) {
+      eventPattern.detail.serviceEventDetails.disableGuardrailStatus.organizationalUnits = [
+        {
+          organizationalUnitName: props.ouName,
+          organizationalUnitId: props.ouId,
+        },
+      ];
+    };
+
+    if (props.guardrailId || props.guardrailBehavior) {
+      eventPattern.detail.serviceEventDetails.disableGuardrailStatus.guardrails = [
+        {
+          guardrailId: props.guardrailId,
+          guardrailBehavior: props.guardrailBehavior,
+        },
+      ];
     };
 
     const description = props.description ?? 'A rule for disabled guardrails in Control Tower.';
@@ -282,7 +302,7 @@ export class DisabledGuardrailRule extends events.Rule {
  */
 export class EnabledGuardrailRule extends events.Rule {
   constructor(scope: Construct, id: string, props: GuardrailRuleProps) {
-    const eventPattern = {
+    let eventPattern:any = {
       source: ['aws.organizations'],
       detailType: ['AWS Service Event via CloudTrail'],
       detail: {
@@ -307,6 +327,24 @@ export class EnabledGuardrailRule extends events.Rule {
           },
         },
       },
+    };
+
+    if (props.ouId || props.ouName) {
+      eventPattern.detail.serviceEventDetails.enableGuardrailStatus.organizationalUnits = [
+        {
+          organizationalUnitName: props.ouName,
+          organizationalUnitId: props.ouId,
+        },
+      ];
+    };
+
+    if (props.guardrailId || props.guardrailBehavior) {
+      eventPattern.detail.serviceEventDetails.enableGuardrailStatus.guardrails = [
+        {
+          guardrailId: props.guardrailId,
+          guardrailBehavior: props.guardrailBehavior,
+        },
+      ];
     };
 
     const description = props.description ?? 'A rule for enabled guardrails in Control Tower.';

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -47,7 +47,6 @@ Object {
             ],
             "serviceEventDetails": Object {
               "createManagedAccountStatus": Object {
-                "organizationalUnit": Object {},
                 "state": Array [
                   "SUCCEEDED",
                 ],
@@ -75,8 +74,6 @@ Object {
             ],
             "serviceEventDetails": Object {
               "updateManagedAccountStatus": Object {
-                "account": Object {},
-                "organizationalUnit": Object {},
                 "state": Array [
                   "SUCCEEDED",
                 ],
@@ -110,6 +107,39 @@ Object {
                 },
                 "organizationalUnit": Object {
                   "organizationalUnitId": "o-123456789012",
+                  "organizationalUnitName": "ExampleOrganizationalUnit",
+                },
+                "state": Array [
+                  "SUCCEEDED",
+                ],
+              },
+            },
+          },
+          "detail-type": Array [
+            "AWS Service Event via CloudTrail",
+          ],
+          "source": Array [
+            "aws.organizations",
+          ],
+        },
+        "State": "ENABLED",
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "UpdatedManagedAccountRuleLessDetailed613FEC73": Object {
+      "Properties": Object {
+        "Description": "A rule for updated accounts managed by Control Tower.",
+        "EventPattern": Object {
+          "detail": Object {
+            "eventName": Array [
+              "UpdateManagedAccount",
+            ],
+            "serviceEventDetails": Object {
+              "updateManagedAccountStatus": Object {
+                "account": Object {
+                  "accountName": "ExampleAccount",
+                },
+                "organizationalUnit": Object {
                   "organizationalUnitName": "ExampleOrganizationalUnit",
                 },
                 "state": Array [

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -18,6 +18,10 @@ test('Snapshot', () => {
     ouId: 'o-123456789012',
     ouName: 'ExampleOrganizationalUnit',
   });
+  new UpdatedManagedAccountRule(stack, 'UpdatedManagedAccountRuleLessDetailed', {
+    accountName: 'ExampleAccount',
+    ouName: 'ExampleOrganizationalUnit',
+  });
   new UpdatedManagedAccountRule(stack, 'UpdatedManagedAccountRule', {});
 
   expect(Template.fromStack(stack)).toMatchSnapshot();


### PR DESCRIPTION
CloudFormation emits an error stating `Event pattern is not valid. Reason: Empty objects are not allowed at <location>` when a property is undefined for more detailed rule setups. This change only adds the object properties in the event that the appropriate props are given rather then leaves them empty.